### PR TITLE
feat(docker): add start.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,34 @@
 TODO: This section need to be updated
 ```
 
-## Installation guide
+## How to start the application
 
 ### System requirement
+
+* Docker: 18.x
+* Docker Compose: 1.24
+
+### Build & start
+
+```sh
+sh start.sh
+```
+
+**Note**: To stop and clean up all services: run `sh start.sh down`.
+
+## All services
+
+Assume there is no customized configuration and we are talking about *localhost*.
+
+* Prisma:
+  * GraphQL Playground: [http://localhost:4466](http://localhost:4466)
+  * Admin: [http://localhost:4466/_admin](http://localhost:4466/_admin)
+* Server: [http://localhost:8000/graphql](http://localhost:8000/graphql)
+* Client: [http://localhost:3000](http://localhost:3000)
+
+## Development guideline
+
+### Development system requirement
 
 * Docker: 18.x [Windows users](https://github.com/penta-jelly/re-radio/wiki/Docker-for-Windows)
 * Docker Compose: 1.x
@@ -45,12 +70,3 @@ sh dev.sh up
 ```sh
 sh dev.sh down
 ```
-
-## All services
-
-* Prisma:
-  * GraphQL Playground: [http://localhost:4466](http://localhost:4466)
-  * Admin: [http://localhost:4466/_admin](http://localhost:4466/_admin)
-* Server: [http://localhost:8000/graphql](http://localhost:8000/graphql)
-* Client: [http://localhost:3000](http://localhost:3000)
-* Storybook: [http://localhost:4000](http://localhost:4000)

--- a/compose/docker-compose.db.yml
+++ b/compose/docker-compose.db.yml
@@ -4,8 +4,6 @@ services:
     container_name: re-radio_prisma
     image: prismagraphql/prisma:1.31.0
     restart: "no"
-    ports:
-      - "${PRISMA_PORT}:${PRISMA_PORT}"
     environment:
       PRISMA_CONFIG: |
         port: ${PRISMA_PORT}
@@ -21,8 +19,6 @@ services:
     container_name: re-radio_db
     image: postgres:10-alpine
     restart: "no"
-    ports:
-      - "${DB_PORT}:${DB_PORT}"
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -1,5 +1,8 @@
 version: "3.7"
 services:
+  prisma:
+    ports:
+      - "${PRISMA_PORT}:${PRISMA_PORT}"
   graphql_service:
     container_name: re-radio_graphql_service
     build:

--- a/compose/docker-compose.test.yml
+++ b/compose/docker-compose.test.yml
@@ -1,5 +1,8 @@
 version: "3.7"
 services:
+  prisma:
+    ports:
+      - "${PRISMA_PORT}:${PRISMA_PORT}"
   graphql_service:
     container_name: re-radio_graphql_service
     build:

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3.7"
+services:
+  prisma:
+    restart: ${DOCKER_CONTAINER_RESTART_POLICY}
+    ports:
+      - "${DOCKER_HOST_PRISMA_PORT}:${PRISMA_PORT}"
+  db:
+    restart: ${DOCKER_CONTAINER_RESTART_POLICY}
+    ports:
+      - "${DOCKER_HOST_DB_PORT}:${DB_PORT}"
+  graphql_service:
+    container_name: re-radio_graphql_service
+    restart: ${DOCKER_CONTAINER_RESTART_POLICY}
+    build:
+      context: ./server
+    ports:
+      - "${DOCKER_HOST_SERVER_PORT}:8000"
+    command: >
+      sh -c "npx wait-on http://prisma:${PRISMA_PORT} && npm run prisma:deploy && npm start"
+    environment:
+      - "YOUTUBE_API_KEY=${YOUTUBE_API_KEY}"
+      - "NODE_ENV=production"
+  real-time_service:
+    container_name: re-radio_real-time_service
+    restart: ${DOCKER_CONTAINER_RESTART_POLICY}
+    build:
+      context: ./server
+    command: >
+      sh -c "npx wait-on http://graphql_service:8000/status && npm run start:real-time-radio"
+    environment:
+      - "YOUTUBE_API_KEY=${YOUTUBE_API_KEY}"
+      - "NODE_ENV=production"
+  client:
+    container_name: re-radio_client
+    restart: ${DOCKER_CONTAINER_RESTART_POLICY}
+    build:
+      context: ./client
+      target: bundle-stage
+    ports:
+      - "${DOCKER_HOST_CLIENT_PORT}:3000"
+    environment:
+      - "NODE_ENV=production"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cp ./server/.env.example ./server/.env
+cp ./client/.env.example ./client/.env
+
+# Merge other mono repository dotenv files into 1 global file
+cat server/.env client/.env > .env
+# Default environment variables
+echo "DOCKER_HOST_DB_PORT=5432" >> .env
+echo "DOCKER_HOST_PRISMA_PORT=4466" >> .env
+echo "DOCKER_HOST_CLIENT_PORT=3000" >> .env
+echo "DOCKER_HOST_SERVER_PORT=8000" >> .env
+echo "DOCKER_CONTAINER_RESTART_POLICY=no" >> .env
+
+# Base executed script
+base="docker-compose \
+  -f ./compose/docker-compose.db.yml \
+  -f ./compose/docker-compose.yml \
+  --project-directory . \
+"
+
+case "$1" in
+'up' | 'down' | 'start' | 'stop' | 'config' | 'build')
+  eval "$base $1 $2 $3"
+;;
+*)
+  eval "$base up $1 $2"
+esac


### PR DESCRIPTION
- `db` container no longer expose its port to the host.
- `prisma` are expected to be used when we want to update a record.
- update README.md with a section about running 1 script for all.